### PR TITLE
Add documentation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .swiftpm
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -27,3 +27,9 @@ let package = Package(
             dependencies: ["CodeEditKit"]),
     ]
 )
+
+#if swift(>=5.6)
+package.dependencies += [
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+]
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -13,8 +13,7 @@ let package = Package(
             targets: ["CodeEditKit"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,9 +26,3 @@ let package = Package(
             dependencies: ["CodeEditKit"]),
     ]
 )
-
-#if swift(>=5.6)
-package.dependencies += [
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-]
-#endif

--- a/bin/generate_docc.sh
+++ b/bin/generate_docc.sh
@@ -1,0 +1,15 @@
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+PACKAGE_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+swift package \
+    --allow-writing-to-directory "$PACKAGE_ROOT/docs" \
+    generate-documentation \
+    --target CodeEditKit \
+    --disable-indexing \
+    --output-path "$PACKAGE_ROOT/docs"

--- a/bin/preview_docc.sh
+++ b/bin/preview_docc.sh
@@ -1,0 +1,13 @@
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+PACKAGE_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+swift package \
+    --disable-sandbox \
+    preview-documentation \
+    --target CodeEditKit

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+# Updates the GitHub Pages documentation site thats published from the 'docs' 
+# subdirectory in the 'gh-pages' branch of this repository.
+#
+# This script should be run by someone with commit access to the 'gh-pages' branch
+# at a regular frequency so that the documentation content on the GitHub Pages site
+# is up-to-date with the content in this repo.
+#
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+PACKAGE_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+# Set current directory to the repository root
+cd "$PACKAGE_ROOT"
+
+# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+git fetch
+git worktree add --checkout gh-pages origin/gh-pages
+
+# Pretty print DocC JSON output so that it can be consistently diffed between commits
+export DOCC_JSON_PRETTYPRINT="YES"
+
+# Generate documentation for the 'CodeEditKit' target and output it
+# to the /docs subdirectory in the gh-pages worktree directory.
+swift package \
+    --allow-writing-to-directory "$PACKAGE_ROOT/gh-pages/docs" \
+    generate-documentation \
+    --target CodeEditKit \
+    --disable-indexing \
+    --hosting-base-path CodeEditKit \
+    --output-path "$PACKAGE_ROOT/gh-pages/docs"
+
+# Save the current commit we've just built documentation from in a variable
+CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+
+# Commit and push our changes to the gh-pages branch
+cd gh-pages
+git add docs
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Documentation changes found. Committing the changes to the 'gh-pages' branch and pushing to origin."
+    git commit -m "Update GitHub Pages documentation site to $CURRENT_COMMIT_HASH"
+    git push origin HEAD:gh-pages
+else
+    # No changes found, nothing to commit.
+    echo "No documentation changes found."
+fi
+
+# Delete the git worktree we created
+cd ..
+git worktree remove gh-pages

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -8,10 +8,10 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 #
-# Updates the GitHub Pages documentation site thats published from the 'docs' 
-# subdirectory in the 'gh-pages' branch of this repository.
+# Updates the GitHub Pages documentation site thats published from the root 
+# directory in the 'docs' branch of this repository.
 #
-# This script should be run by someone with commit access to the 'gh-pages' branch
+# This script should be run by someone with commit access to the 'docs' branch
 # at a regular frequency so that the documentation content on the GitHub Pages site
 # is up-to-date with the content in this repo.
 #
@@ -28,34 +28,34 @@ PACKAGE_ROOT="$(dirname $(dirname $(filepath $0)))"
 # Set current directory to the repository root
 cd "$PACKAGE_ROOT"
 
-# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+# Use git worktree to checkout the docs branch of this repository in a docs sub-directory
 git fetch
-git worktree add --checkout gh-pages origin/gh-pages
+git worktree add --checkout docs origin/docs
 
 # Pretty print DocC JSON output so that it can be consistently diffed between commits
 export DOCC_JSON_PRETTYPRINT="YES"
 
 # Generate documentation for the 'CodeEditKit' target and output it
-# to the /docs subdirectory in the gh-pages worktree directory.
+# to the /docs subdirectory in the docs worktree directory.
 swift package \
-    --allow-writing-to-directory "$PACKAGE_ROOT/gh-pages/docs" \
+    --allow-writing-to-directory "$PACKAGE_ROOT/docs" \
     generate-documentation \
     --target CodeEditKit \
     --disable-indexing \
     --hosting-base-path CodeEditKit \
-    --output-path "$PACKAGE_ROOT/gh-pages/docs"
+    --output-path "$PACKAGE_ROOT/docs"
 
 # Save the current commit we've just built documentation from in a variable
 CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
 
-# Commit and push our changes to the gh-pages branch
-cd gh-pages
-git add docs
+# Commit and push our changes to the docs branch
+cd docs
+git add .
 
 if [ -n "$(git status --porcelain)" ]; then
-    echo "Documentation changes found. Committing the changes to the 'gh-pages' branch and pushing to origin."
+    echo "Documentation changes found. Committing the changes to the 'docs' branch and pushing to origin."
     git commit -m "Update GitHub Pages documentation site to $CURRENT_COMMIT_HASH"
-    git push origin HEAD:gh-pages
+    git push origin HEAD:docs
 else
     # No changes found, nothing to commit.
     echo "No documentation changes found."
@@ -63,4 +63,4 @@ fi
 
 # Delete the git worktree we created
 cd ..
-git worktree remove gh-pages
+git worktree remove docs


### PR DESCRIPTION
Add basic swift docc support for CodeEditKit

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/43724855/193089960-0b7fdea1-6716-4018-8b5e-b36370570579.png">

Next Step:
- [ ] Add a "gh-pages" branch with a simple commit (Maybe adding a .gitignore file)
- [ ] Run `bin/update-gh-pages-documentation-site`

Then we can get http://CodeEditApp.github.io/CodeEditKit/documentation/codeeditkit to host the documentation

See demo at http://kyle-ye.github.io/CodeEditKit/documentation/codeeditkit