### PR TITLE
[Chore]: Add workflows for `swiftlint`, `test`, and `build-documentation`

### DIFF
--- a/.github/scripts/tests.sh
+++ b/.github/scripts/tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+ARCH=""
+    
+if [ $1 = "arm" ]
+then
+    ARCH="arm64"
+else
+    ARCH="x86_64"
+fi
+
+echo "Building with arch: ${ARCH}"
+
+export LC_CTYPE=en_US.UTF-8
+
+set -o pipefail && arch -"${ARCH}" xcodebuild  \
+           -scheme CodeEditKit \
+           -derivedDataPath ".build" \
+           -destination "platform=macos,arch=${ARCH}" \
+           clean test | xcpretty

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,42 @@
+name: build-documentation
+on: 
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'Sources/**'
+jobs:
+  build-docc:
+    runs-on: macos-12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - uses: actions/cache@v3
+        with:
+          path: '.build'
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+      - uses: fwcd/swift-docc-action@v1.0.2
+        with:
+          target: CodeEditKit
+          output: ./docs
+          hosting-base-path: CodeEditKit
+          disable-indexing: 'true'
+          transform-for-static-hosting: 'true'
+      - name: Init new repo in dist folder and commit generated files
+        run: |
+          cd docs
+          git init
+          git add -A
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m 'deploy'
+        
+      - name: Force push to destination branch
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: docs
+          force: true
+          directory: ./docs

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,25 @@
+name: SwiftLint
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: GitHub Action for SwiftLint with --strict
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: tests
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'Sources/**'
+      - 'Tests/**'
+  pull_request:
+    branches:
+      - 'main'
+jobs:
+  code-edit-text-view-tests:
+    name: Testing CodeEditTextView
+    runs-on: macos-12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - uses: actions/cache@v3
+        with:
+          path: '.build'
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+      - name: Make executeable
+        run: chmod +x ./.github/scripts/tests.sh
+      - name: Testing Package
+        run: exec ./.github/scripts/tests.sh

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,16 @@
+disabled_rules:
+  - todo
+  - trailing_comma
+  - nesting
+
+type_name:
+  excluded:
+    - ID
+
+identifier_name:
+  min_length: 2
+  allowed_symbols: ['_']
+  excluded:
+    - c
+    - id
+    - vc

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
             targets: ["CodeEditKit"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
     ],

--- a/Sources/CodeEditKit/Documentation.docc/Documentation.md
+++ b/Sources/CodeEditKit/Documentation.docc/Documentation.md
@@ -1,0 +1,7 @@
+# ``CodeEditKit``
+
+CodeEditKit is a dynamic library which is shared between CodeEdit and it's extensions. It allows them to communicate with and understand one another.
+
+## Overview
+
+This is still work in progress.

--- a/Sources/CodeEditKit/Targets/Target.swift
+++ b/Sources/CodeEditKit/Targets/Target.swift
@@ -32,22 +32,22 @@ public struct Target: Identifiable {
         self.execName = execName
     }
 
-    /// ``id`` is a unique identifier of the target set by the extension
+    /// `id` is a unique identifier of the target set by the extension
     public var id: String
 
-    /// ``displayName`` is a name to be displayed in the UI to represent target
+    /// `displayName` is a name to be displayed in the UI to represent target
     public var displayName: String
 
-    /// ``executable`` is the executable to launch inside the pseudo terminal
+    /// `executable` is the executable to launch inside the pseudo terminal
     public var executable: String
 
-    /// ``args`` is an array of strings that is passed as the arguments to the underlying process
+    /// `args` is an array of strings that is passed as the arguments to the underlying process
     public var args: [String] = []
 
-    /// ``environment`` is an array of environment variables to pass to the child process.
+    /// `environment` is an array of environment variables to pass to the child process.
     public var environment: [String]?
 
-    /// ``execName`` If provided, this is used as the Unix argv[0] parameter, otherwise,
+    /// `execName` If provided, this is used as the Unix argv[0] parameter, otherwise,
     /// the executable is used as the args [0], this is used when the intent is to set a different
     /// process name than the file that backs it.
     public var execName: String?

--- a/Sources/CodeEditKit/Targets/Target.swift
+++ b/Sources/CodeEditKit/Targets/Target.swift
@@ -17,7 +17,9 @@ public struct Target: Identifiable {
      * - Parameter executable: The executable to launch inside the pseudo terminal
      * - Parameter args: an array of strings that is passed as the arguments to the underlying process
      * - Parameter environment: an array of environment variables to pass to the child process.
-     * - Parameter execName: If provided, this is used as the Unix argv[0] parameter, otherwise, the executable is used as the args [0], this is used when the intent is to set a different process name than the file that backs it.
+     * - Parameter execName: If provided, this is used as the Unix argv[0] parameter, otherwise,
+     * the executable is used as the args [0], this is used when the intent is to set a different process name
+     * than the file that backs it.
      */
     public init(id: String, displayName: String,
                 executable: String, args: [String] = [],
@@ -45,6 +47,8 @@ public struct Target: Identifiable {
     /// ``environment`` is an array of environment variables to pass to the child process.
     public var environment: [String]?
 
-    /// ``execName`` If provided, this is used as the Unix argv[0] parameter, otherwise, the executable is used as the args [0], this is used when the intent is to set a different process name than the file that backs it.
+    /// ``execName`` If provided, this is used as the Unix argv[0] parameter, otherwise,
+    /// the executable is used as the args [0], this is used when the intent is to set a different
+    /// process name than the file that backs it.
     public var execName: String?
 }

--- a/Tests/CodeEditKitTests/CEExtensionKitTests.swift
+++ b/Tests/CodeEditKitTests/CEExtensionKitTests.swift
@@ -3,8 +3,6 @@ import XCTest
 
 final class CEExtensionKitTests: XCTestCase {
     func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
+        XCTAssertTrue(true)
     }
 }


### PR DESCRIPTION
In order to have a solid foundation up and running once we start building our Extensions API I added the following workflows similar to our other repos:

- Added `SwiftLint` workflow
  - added `.swiftlint.yml`
  - fixed lint errors
- Added `Tests` workflow.
  - added sample test case which always succeeds.
- Added `Build Documentation` workflow.
  - Same as in `CodeEditTextView`