### PR TITLE
[chore]: remove package comments, update docs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,10 @@
-// swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.6
 
 import PackageDescription
 
 let package = Package(
     name: "CodeEditKit",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "CodeEditKit",
             type: .dynamic,
@@ -14,12 +12,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "CodeEditKit",
             dependencies: []),

--- a/Sources/CodeEditKit/Documentation.docc/Documentation.md
+++ b/Sources/CodeEditKit/Documentation.docc/Documentation.md
@@ -4,4 +4,6 @@ CodeEditKit is a dynamic library which is shared between CodeEdit and it's exten
 
 ## Overview
 
-This is still work in progress.
+This is still work in progress. 
+
+> See [this thread](https://github.com/orgs/CodeEditApp/discussions/792) for more information.


### PR DESCRIPTION
- remove standard comments from `Package.swift`
- bump `swift-tools-version` to `5.6`
- add link to extensions architecture discussion to the documentation